### PR TITLE
Update Renovate configuration to use centralized config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,3 @@
 {
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "groupName": "Weekly Automated Updates",
-      "schedule": ["on Sunday at 23:00"]
-    }
-  ]
+  "extends": ["github>pcartwright81/renovate-default-config"]
 }


### PR DESCRIPTION
This PR updates the renovate.json file to use the centralized configuration from `renovate-default-config`.

## Changes
- Replaced custom packageRules with extends reference
- All configuration is now managed centrally in the renovate-default-config repository

This simplifies maintenance and ensures consistency across all repositories.